### PR TITLE
Initial project codebase

### DIFF
--- a/Rpatentmap.Rproj
+++ b/Rpatentmap.Rproj
@@ -1,0 +1,13 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX

--- a/data/README.txt
+++ b/data/README.txt
@@ -1,0 +1,4 @@
+TO SPEED UP REPRODUCTION DATA IS AVAILABLE AT:
+https://1drv.ms/f/s!AiYfDSSg7esDhJR8L0siuJhIkfbKzQ?e=aU0dlb
+
+NOTE: SQL/R scripts used to get g-patent data from bigQuery are available in the `g-patents/pre-treatment` folder if one wants to fully reproduce the project

--- a/data/g-patents/.gitignore
+++ b/data/g-patents/.gitignore
@@ -1,0 +1,4 @@
+#Ignore all data
+*.parquet
+*.feather
+*.csv

--- a/data/g-patents/README.txt
+++ b/data/g-patents/README.txt
@@ -1,0 +1,4 @@
+TO REPRODUCE RESULTS PLEASE DOWNLOAD DATA FROM:
+[link to be included]
+
+SQL/R scripts used in bigQuery are available in the `pre-treatment` folder

--- a/data/g-patents/README.txt
+++ b/data/g-patents/README.txt
@@ -1,4 +1,0 @@
-TO REPRODUCE RESULTS PLEASE DOWNLOAD DATA FROM:
-[link to be included]
-
-SQL/R scripts used in bigQuery are available in the `pre-treatment` folder

--- a/data/g-patents/pre-treatment/bq-aggreg.sql
+++ b/data/g-patents/pre-treatment/bq-aggreg.sql
@@ -1,0 +1,46 @@
+--Aggregate per firm, country, kind_code and year
+SELECT
+  SUBSTR(CAST(grant_date AS STRING), 1, 4) AS year,
+  kind_code,
+  assignee,
+  country_code,
+  COUNT(DISTINCT publication_number) AS n
+FROM
+  `patents-public-data.patents.publications`,
+  UNNEST(assignee) as assignee
+GROUP BY
+  year,
+  kind_code,
+  assignee,
+  country_code
+  
+--Aggregate per country, kind_code and year
+SELECT
+  SUBSTR(CAST(grant_date AS STRING), 1, 4) AS year,
+  kind_code,
+  country_code,
+  COUNT(*) AS n
+FROM
+  `patents-public-data.patents.publications`
+GROUP BY
+  year,
+  kind_code,
+  country_code
+  
+--Aggregate per assignee, in the US, 2011
+WITH aggreg1 AS (
+  SELECT
+    assignee.name,
+    COUNT(DISTINCT publication_number) AS n
+  FROM
+    `statsapp_data.final_kindB`,
+    UNNEST(assignee_harmonized) as assignee
+  WHERE 
+    grant_date>20109999 AND grant_date<20119999
+  GROUP BY
+    assignee.name
+)
+
+SELECT *
+FROM aggreg1
+WHERE n>10

--- a/data/g-patents/pre-treatment/bq-all-citations.sql
+++ b/data/g-patents/pre-treatment/bq-all-citations.sql
@@ -1,0 +1,29 @@
+--STEP 1: SELECT ALL VARIABLES OF INTEREST FROM THE PATENTS DATABASE
+SELECT 
+	publication_number, 
+	country_code,
+	kind_code,
+	publication_date,
+	grant_date,
+	assignee_harmonized,
+	ipc, 
+	cpc,
+	SUBSTR(CAST(grant_date AS STRING), 1, 4) AS year
+FROM 
+	`patents-public-data.patents.publications` 
+--save data as `full_ipc_cpc`
+
+
+--STEP 2: SELECT ALL DISTINCT PUBLICATION_NUMBER CITED IN THE US-B1-B2 DATABASE (final_kindB)
+SELECT DISTINCT citation_detail.publication_number AS citation_pub_num
+FROM `uplifted-nuance-405910.statsapp_data.final_kindB` fb
+CROSS JOIN UNNEST(fb.citation) AS citation_detail
+--save data as `all_citation`
+
+
+--STEP 3: 
+SELECT *
+FROM `statsapp_data.all_citation`
+JOIN `uplifted-nuance-405910.statsapp_data.full_ipc_cpc` f 
+ON citation_pub_num = f.publication_number
+--data exported

--- a/data/g-patents/pre-treatment/bq-final_kindB.sql
+++ b/data/g-patents/pre-treatment/bq-final_kindB.sql
@@ -1,0 +1,31 @@
+SELECT 
+	publication_number, 
+	application_number,
+	country_code,
+	kind_code,
+	application_kind,
+	application_number_formatted,
+	pct_number,
+	family_id,
+	spif_publication_number,
+	spif_application_number,
+	publication_date,
+	filing_date,
+	grant_date,
+	inventor_harmonized,
+	assignee_harmonized,
+	examiner,
+	uspc, 
+	ipc, 
+	cpc, 
+	citation,
+	parent, 
+	child,
+	entity_status,
+	art_unit,
+	SUBSTR(CAST(grant_date AS STRING), 1, 4) AS year
+FROM 
+	`patents-public-data.patents.publications` 
+WHERE 
+	country_code="US" AND (kind_code="B2" OR kind_code="B1")
+--save data as `final_kindB`

--- a/data/g-patents/pre-treatment/script_join_parquet.R
+++ b/data/g-patents/pre-treatment/script_join_parquet.R
@@ -1,0 +1,62 @@
+library(parallel)
+library(here)
+i_am("Cloud SDK.Rproj")
+library(arrow)
+library(tidyverse)
+library(data.table)
+
+#Cited patents -----------------------------------------------------------------
+no_cores <- detectCores()-2
+cl <- makeCluster(no_cores)
+
+files <- list.files(path = here("small_citation"), 
+                    full.names = TRUE)
+data_list <- parLapply(cl, files, read_parquet)
+stopCluster(cl)
+
+all_citations <- bind_rows(data_list)
+
+#Write to feather file
+write_feather(all_citations, here("r-exports", "citations.feather"))
+
+#Patents filled in 2011 (B1, B2, US Only) --------------------------------------
+no_cores <- detectCores()-2
+cl <- makeCluster(no_cores)
+
+files <- list.files(path = here("2011_kindB"), 
+                    full.names = TRUE)
+data_list <- parLapply(cl, files, read_parquet)
+stopCluster(cl)
+
+all_USpatents11 <- bind_rows(data_list)
+
+#Write to feather file
+write_feather(all_USpatents11, here("r-exports", "us_patents2011.feather"))
+
+
+#All patents per assignee ------------------------------------------------------
+#If patents are older in other jurisdictions sometime data on the assignee 
+#origin is not available, we can retrive some of that with this "backup"
+
+no_cores <- detectCores()-2
+cl <- makeCluster(no_cores)
+
+files <- list.files(path = here("backup_country"), 
+                    full.names = TRUE)
+data_list <- parLapply(cl, files, read_parquet)
+stopCluster(cl)
+
+all_patents_assignee <- bind_rows(data_list)
+
+#Write to feather file
+write_feather(all_patents_assignee, here("r-exports", "all_patents_assignee.feather"))
+
+#Compute max backup ------------------------------------------------------------
+all_patents_assignee <- setDT(read_feather(here("r-exports", "all_patents_assignee.feather")))
+frequency_table <- all_patents_assignee[, .N, by = .(assignee_name, assignee_country_backup)]
+setorder(frequency_table, assignee_name, -N)
+most_frequent_country <- frequency_table[, .SD[1], by = assignee_name]
+write_feather(most_frequent_country, here("r-exports", "backup_country.feather"))
+
+
+

--- a/data/interim/.gitignore
+++ b/data/interim/.gitignore
@@ -1,0 +1,4 @@
+#Ignore all data
+*.parquet
+*.feather
+*.csv

--- a/src/full_patent_plus.R
+++ b/src/full_patent_plus.R
@@ -1,0 +1,48 @@
+library(here)
+i_am("Rpatentmap.Rproj")
+library(arrow)
+library(tidyverse)
+library(data.table)
+
+citations <- setDT(read_feather(here("data","g-patents", "citations.feather")))
+patents <- setDT(read_feather(here("data","g-patents", "us_patents2011.feather")))
+backup_country <- setDT(read_feather(here("data","g-patents", "backup_country.feather")))
+
+
+setnames(citations, old = names(citations), new = paste0(names(citations), "_cit"))
+
+patents_plus_full <- patents[citations, on = .(citation_pub_num = citation_pub_num_cit), nomatch = 0] 
+patents_plus_full <- left_join(patents_plus_full,
+                               backup_country, 
+                               by = c("assignee_name_cit" = "assignee_name"))
+patents_plus_full[, assignee_country_cit := fifelse(assignee_country_cit=="", assignee_country_backup, assignee_country_cit)]
+#patents_plus_full <- patents_plus_full[assignee_country!=""] #if we decided to filter them out
+
+network <- patents_plus_full[, .(n = .N), by = .(assignee_name, assignee_country, assignee_name_cit, assignee_country_cit)]
+network_noautocit <- patents_plus_full[assignee_name!=assignee_name_cit][, .(n = .N), by = .(assignee_name, assignee_name_cit)]
+
+network_countries <- patents_plus_full[, .(n = .N), by = .(assignee_country, assignee_country_cit)]
+network_countries_noautocit <- patents_plus_full[assignee_name!=assignee_name_cit][, .(n = .N), by = .(assignee_country, assignee_country_cit)]
+
+
+totpatent <- patents_plus_full[, .(tot_patent = uniqueN(publication_number)), by = .(assignee_name)]
+totpatent_cit <- patents_plus_full[, .(tot_patent_cit = uniqueN(citation_pub_num)), by = .(assignee_name_cit)]
+totpatent_full <- totpatent[totpatent_cit, on = .(assignee_name = assignee_name_cit)]%>%
+  rowwise()%>%
+  mutate(sum_patent=sum(tot_patent,tot_patent_cit, na.rm = T))
+
+totpatent_cnt <- patents_plus_full[, .(tot_patent = uniqueN(publication_number)), by = .(assignee_country)]
+totpatent_cnt_cit <- patents_plus_full[, .(tot_patent_cit = uniqueN(citation_pub_num)), by = .(assignee_country_cit)]
+totpatent_cnt_full <- totpatent_cnt[totpatent_cnt_cit, on = .(assignee_country = assignee_country_cit)]%>%
+  rowwise()%>%
+  mutate(sum_patent=sum(tot_patent,tot_patent_cit, na.rm = T))
+
+
+#exports -----------------------------------------------------------------------
+write_feather(patents_plus_full, here("data","interim", "patents_plus_full.feather"))
+write_feather(network, here("data","interim", "network.feather"))
+write_feather(network_noautocit, here("data","interim", "network_noautocit.feather"))
+write_feather(network_countries, here("data","interim", "network_countries.feather"))
+write_feather(network_countries_noautocit, here("data","interim", "network_countries_noautocit.feather"))
+write_feather(totpatent_full, here("data","interim", "totpatent_full.feather"))
+write_feather(totpatent_cnt_full, here("data","interim", "totpatent_cnt_full.feather"))

--- a/src/network-firms-countries.R
+++ b/src/network-firms-countries.R
@@ -1,0 +1,39 @@
+library(here)
+i_am("Rpatentmap.Rproj")
+library(arrow)
+library(tidyverse)
+library(data.table)
+library(igraph)
+
+totpatent_cnt_full <- read_feather(here("data","interim", "totpatent_cnt_full.feather"))
+network_countries_noautocit <- read_feather(here("data","interim", "network_countries_noautocit.feather"))
+
+list <- (totpatent_cnt_full%>%filter(sum_patent>100&!is.na(assignee_country)))$assignee_country
+
+
+network_data <- network_countries_noautocit%>%
+  filter(assignee_country%in%list&assignee_country_cit%in%list)%>%
+           #assignee_country!=assignee_country_cit)%>%
+  rename(to=assignee_country_cit, from=assignee_country, link=n)%>%
+  mutate(link=link*2e-6)
+
+vertices_df <- unique(c(network_data$from, network_data$to))
+edges_df <- network_data[, c("from", "to", "link")]
+
+g <- graph_from_data_frame(d=edges_df, vertices=vertices_df, directed=T)
+
+total_patents_cnt <- as.data.frame(vertices_df)%>%
+  rename(name=vertices_df)%>%
+  left_join(totpatent_cnt_full, by=c("name"="assignee_country"))
+
+V(g)$size <- sqrt(total_patents_cnt$sum_patent)/50
+
+plot(g,layout=layout_with_kk(g), vertex.size=V(g)$size, edge.width=E(g)$link, vertex.label.cex=0.8,
+     vertex.color="lightblue", edge.arrow.size =0.2)
+
+
+title("Innovation links* for firms having been granted a patent in the USA in 2011 by origin")
+
+
+
+

--- a/src/network-firms.R
+++ b/src/network-firms.R
@@ -1,0 +1,61 @@
+library(here)
+i_am("Rpatentmap.Rproj")
+library(arrow)
+library(tidyverse)
+library(data.table)
+library(igraph)
+
+totpatent_full<-read_feather(here("data","interim", "totpatent_full.feather"))
+network<-read_feather(here("data","interim", "network.feather"))
+
+#Links between firms
+list <- (totpatent_full%>%filter(tot_patent>50))$assignee_name
+
+net <- network_noautocit%>%filter(n>450&assignee_name%in%list)%>%
+  rename(from=assignee_name_cit, to=assignee_name, link=n)%>%
+  mutate(link=sqrt(link)*55e-3)
+
+vertices <- unique(c(net$from, net$to))
+edges <- net[, c("from", "to", "link")]
+
+g <- graph_from_data_frame(d=edges, vertices=vertices, directed=TRUE)
+
+total_patents <- as.data.frame(vertices)%>%
+  rename(name=vertices)%>%
+  left_join(totpatent_full, by=c("name"="assignee_name"))
+
+V(g)$size <- sqrt(total_patents$sum_patent)*55e-3
+
+plot(g,layout=layout_with_fr(g), vertex.size=V(g)$size, edge.width=E(g)$link, vertex.label.cex=0.4,
+     vertex.color="lightblue", edge.arrow.size =0.2)
+title("Innovation links for firms that were granted at least 50 patents in the US in 2011", 
+      sub = "*sqrt of combined citations between firms, citations from 1945 onward")
+
+
+
+#Without direction version
+net$pair <- apply(net[, c('from', 'to')], 1, function(x) paste(sort(x), collapse = "-"))
+
+# Aggregate data
+aggregated_net <- net %>%
+  group_by(pair) %>%
+  summarise(link = sum(link)) %>%
+  mutate(from = sapply(strsplit(as.character(pair), "-"), `[`, 1),
+         to = sapply(strsplit(as.character(pair), "-"), `[`, 2),
+         link=log(link)*0.5)
+
+vertices <- unique(c(aggregated_net$from, aggregated_net$to))
+edges <- aggregated_net[, c("from", "to", "link")]
+
+g <- graph_from_data_frame(d=edges, vertices=vertices, directed=F)
+
+total_patents <- as.data.frame(vertices)%>%
+  rename(name=vertices)%>%
+  left_join(totpatent_full, by=c("name"="assignee_name"))
+
+V(g)$size <- log(total_patents$sum_patent)*0.85
+
+plot(g,layout=layout_with_fr(g), vertex.size=V(g)$size, edge.width=E(g)$link, vertex.label.cex=0.4,
+     vertex.color="lightblue")
+title("Top 250 innovation links* for firms having been granted a patent in the USA in 2011", 
+      sub = "*log of combined citations between firms, citations from 1945 onward")


### PR DESCRIPTION
## Initial Codebase
This initial codebase is designed to enable contributors to experiment with various network definitions. It facilitates the process by allowing the filtering of years, patent offices, kind codes, etc., in the  `citations.feather` file using the `full_patent_plus.R` script.

**Note:** Data can be directly downloaded (refer to `data/README.txt`) and used to run the project, eliminating the need to download Google's patent data from BigQuery. Several improvements can be implemented swiftly. For example, minimizing the number of library calls in each script, integrating R/SQL code for easier replication of results using BigQuery, or developing a custom function for network plots could enhance the project's efficiency and user-friendliness.